### PR TITLE
GMT+5:30 India was added.

### DIFF
--- a/src/timezones.json
+++ b/src/timezones.json
@@ -72,6 +72,7 @@
   "(GMT+05:00) Karachi": "Asia/Karachi",
   "(GMT+05:00) Moscow+02 - Yekaterinburg": "Asia/Yekaterinburg",
   "(GMT+05:00) Tashkent": "Asia/Tashkent",
+  "(GMT+05:30) India": "Asia/Kolkata",
   "(GMT+05:30) Colombo": "Asia/Colombo",
   "(GMT+06:00) Almaty": "Asia/Almaty",
   "(GMT+06:00) Dhaka": "Asia/Dhaka",


### PR DESCRIPTION
As GMT+5:30 is vastly used by India I have added that along with Colombo which is also Sri Lanka's time but if someone is using your libaray from India he couldn't find this in your json file which is being used for the drop down library for react.